### PR TITLE
Application crash on generate scheme

### DIFF
--- a/packages/taxios-generate/src/bin.ts
+++ b/packages/taxios-generate/src/bin.ts
@@ -83,7 +83,7 @@ async function schemaToTsTypeExpression(
     sortFields(wrappedSchema);
   }
 
-  const rawTsWrappedInterface = await compile(wrappedSchema, 'Temp', { bannerComment: '' });
+  const rawTsWrappedInterface = await compile(wrappedSchema, 'Temp', { bannerComment: '', ignoreMinAndMaxItems: true });
 
   // @TODO: Use some different way to generate typescript types from json schema,
   //        because using temporary files is meh
@@ -149,7 +149,11 @@ async function schemaToTsTypeDeclaration(
     }
   }
 
-  const rawTsTypeDeclaration = await compile(schema, name, { bannerComment: '', enableConstEnums: false });
+  const rawTsTypeDeclaration = await compile(schema, name, {
+    bannerComment: '',
+    enableConstEnums: false,
+    ignoreMinAndMaxItems: true,
+  });
 
   // @NOTE: json-schema-to-typescript forcibly converts type names to CamelCase,
   //        so we have to convert them back to original casing if possible


### PR DESCRIPTION
This happens when array scheme contain fields like minItmes or maxItems with large number value.
